### PR TITLE
Remove the need to wrap views in 'withSSRData'

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Runs linter.
 Only views can be SSR. Views are components that directly connected to a URL. To do SSR you need just 2 simple steps:
 
 
-* Add `serverSideInitial` static method to your view to do side-effects, dispatch actions to store or return values and promises.
+* Just add `serverSideInitial` static method to your view to do side-effects, dispatch actions to store or return values and promises.
 
 ```
  static serverSideInitial({ dispatch, req }) {
@@ -85,7 +85,7 @@ Only views can be SSR. Views are components that directly connected to a URL. To
 
 ```
 
-* Wrap the view with `withSSRData` HOC to get value returned by `serverSideInitial` as `props.initialSSRData`.
+* Now get value returned by `serverSideInitial` as `props.initialSSRData`.
 
 ```
 Component.propTypes = {
@@ -93,7 +93,7 @@ Component.propTypes = {
    posts: PropTypes.array(),
 };
  
-export default withSSRData(Component);
+export default Component;
 ```
 
 ## Directory Layout

--- a/src/AppRouter.jsx
+++ b/src/AppRouter.jsx
@@ -1,6 +1,6 @@
-import { renderRoutes } from 'react-router-config';
-
 import routes from 'src/configs/routes';
+
+import { renderRoutes } from './server/utils';
 
 function AppRouter() {
   return renderRoutes(routes);

--- a/src/configs/routes.js
+++ b/src/configs/routes.js
@@ -2,6 +2,7 @@ import Home from 'src/views/Home';
 
 const routes = [
   {
+    path: '/',
     component: Home,
   },
 ];

--- a/src/server/handlers/ssr-handler.js
+++ b/src/server/handlers/ssr-handler.js
@@ -53,17 +53,21 @@ function getInitialPropsList({ renderBranch, store: { getState, dispatch }, req 
       // to find the final wrapped component which contains the static server-side methods
       const {
         component: { serverSideInitial },
-        hasSSRData: hasPreloadedData,
+        hasSSRData: wrappedInWithSSRData,
       } = findFinalComponent(component);
 
       if (!serverSideInitial) {
         return initialPropsList;
       }
 
+      const dataPromise = serverSideInitial({ getState, dispatch, req });
+      const serverSideInitialReturns = dataPromise !== undefined;
+      const hasPreloadedData = serverSideInitialReturns || wrappedInWithSSRData;
+
       return initialPropsList.concat({
         path,
         hasPreloadedData,
-        dataPromise: serverSideInitial({ getState, dispatch, req }),
+        dataPromise,
       });
     },
     [],

--- a/src/server/handlers/ssr-handler.js
+++ b/src/server/handlers/ssr-handler.js
@@ -13,7 +13,7 @@ import { initSSRContextValue } from 'src/services/initial-ssr-data/utils';
 import { getEnv, isProd } from 'src/utils/env';
 import AppRouter from 'src/AppRouter';
 
-import { findFinalComponent } from '../utils';
+import { findFinalComponent, getComponent } from '../utils';
 import pageTemplate from '../templates/page-template.hbs';
 
 // eslint-disable-next-line import/no-dynamic-require
@@ -45,7 +45,10 @@ function renderPage({ appHtml, preloadedData, preloadedState }) {
 
 function getInitialPropsList({ renderBranch, store: { getState, dispatch }, req }) {
   return renderBranch.reduce(
-    (initialPropsList, { route: { component, path } }) => {
+    (initialPropsList, { route: { component: routeComponent, render: routeRenderer, path } }) => {
+
+      const component = getComponent(routeComponent, routeRenderer);
+
       // Due to usage of HOCs, we have to traverse the component tree
       // to find the final wrapped component which contains the static server-side methods
       const {

--- a/src/server/handlers/ssr-handler.js
+++ b/src/server/handlers/ssr-handler.js
@@ -45,8 +45,16 @@ function renderPage({ appHtml, preloadedData, preloadedState }) {
 
 function getInitialPropsList({ renderBranch, store: { getState, dispatch }, req }) {
   return renderBranch.reduce(
-    (initialPropsList, { route: { component: routeComponent, render: routeRenderer, path } }) => {
-
+    (
+      initialPropsList,
+      {
+        route:
+         {
+           component: routeComponent,
+           render: routeRenderer, path,
+         },
+      },
+    ) => {
       const component = getComponent(routeComponent, routeRenderer);
 
       // Due to usage of HOCs, we have to traverse the component tree

--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -20,3 +20,12 @@ export function findFinalComponent(component) {
     hasSSRData: isWrappedInWithSSRDataHOC,
   };
 }
+
+export function getComponent(component, routeRenderer) {
+  // because route renderers are a wrapper around the actual component,
+  // they return the element created by react and not the actual component so we 
+  // need to point to the actual component which is stored in the 'type' property
+  // in the returned react element
+  const reactElement = routeRenderer ? routeRenderer() : null;
+  return reactElement ? reactElement.type : component;
+}

--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -1,4 +1,9 @@
+import React from 'react';
+import { Switch, Route } from 'react-router-dom';
+
 import { getEnv } from 'src/utils/env';
+
+import withSSRData from '../shared-components/withSSRData';
 
 // Due to usage of HOCs, we have to traverse the component tree to find the
 // final wrapped component which contains the static server-side methods
@@ -28,4 +33,35 @@ export function getComponent(component, routeRenderer) {
   // in the returned react element
   const reactElement = routeRenderer ? routeRenderer() : null;
   return reactElement ? reactElement.type : component;
+}
+
+export function renderRoutes(routes, extraProps = {}, switchProps = {}) {
+  if (!routes) return null;
+
+  return (
+    <Switch {...switchProps}>
+      {routes.map((route, index) => {
+        const { component: routeComponent, render: routeRenderer, ...rest } = route;
+        const component = getComponent(routeComponent, routeRenderer);
+        const { hasSSRData: wrappedInWithSSRData } = findFinalComponent(component);
+        const hasServerSideInitial = component.serverSideInitial;
+        const needsWithSSRData = hasServerSideInitial && !wrappedInWithSSRData;
+
+        /* eslint react/no-array-index-key: 0 */
+        return (
+          <Route
+            key={`route--${index}`}
+            {...rest}
+            render={(props) => {
+              const componentProps = { ...props, ...extraProps, route };
+
+              return (needsWithSSRData)
+                ? React.createElement(withSSRData(component), componentProps)
+                : React.createElement(component, componentProps)
+            }}
+          />
+        )
+      })}
+    </Switch>
+  );
 }

--- a/src/server/utils.js
+++ b/src/server/utils.js
@@ -2,8 +2,7 @@ import React from 'react';
 import { Switch, Route } from 'react-router-dom';
 
 import { getEnv } from 'src/utils/env';
-
-import withSSRData from '../shared-components/withSSRData';
+import withSSRData from 'src/services/initial-ssr-data/withSSRData';
 
 // Due to usage of HOCs, we have to traverse the component tree to find the
 // final wrapped component which contains the static server-side methods
@@ -28,10 +27,11 @@ export function findFinalComponent(component) {
 
 export function getComponent(component, routeRenderer) {
   // because route renderers are a wrapper around the actual component,
-  // they return the element created by react and not the actual component so we 
+  // they return the element created by react and not the actual component so we
   // need to point to the actual component which is stored in the 'type' property
   // in the returned react element
   const reactElement = routeRenderer ? routeRenderer() : null;
+
   return reactElement ? reactElement.type : component;
 }
 
@@ -57,10 +57,10 @@ export function renderRoutes(routes, extraProps = {}, switchProps = {}) {
 
               return (needsWithSSRData)
                 ? React.createElement(withSSRData(component), componentProps)
-                : React.createElement(component, componentProps)
+                : React.createElement(component, componentProps);
             }}
           />
-        )
+        );
       })}
     </Switch>
   );

--- a/src/services/initial-ssr-data/withSSRData.jsx
+++ b/src/services/initial-ssr-data/withSSRData.jsx
@@ -2,9 +2,10 @@ import React, { Component } from 'react';
 import { withRouter } from 'react-router';
 import PropTypes from 'prop-types';
 
-import { getContext } from 'src/services/initial-ssr-data';
 import { getDisplayName } from 'src/utils/hoc';
 import { getEnv } from 'src/utils/env';
+
+import { getContext } from './index';
 
 function withSSRData(WrappedComponent) {
   class WithSSRDataComponent extends Component {


### PR DESCRIPTION
First of all, sorry for opening a pull request since you guys mentioned open an issue first, but because I wanted there to be a working example of what's being discussed rather than talking about it abstractly I opened a PR. But there is no obligation on you guys and it's ok you if you want to dismiss the work that has been done.

## Main Changes

I think the need for wrapping the views in `withSSRData` is an unnecessary and extra step, and may lead to bugs since you may forget to add it. It also can be unfamiliar to other people since other frameworks don't use HOCs to pass the server side props.
Since the logic of it is necessary for views, I used the same component but moved the duty of wrapping the view in it from component level to the route level .

This is possible by implementing the same exact api and functionality as `renderRoutes` that is provided by `react-router-config` but with the extra logic for wrapping components in `withSSRData` if they've used `serverSideInitial`. This change is also compatible with the old way of writing views that are explicitly wrapped in `withSSRData`.

Because wrapping the view is done implicitly in the route level now, the old logic for `hasPreloadedData` that was returned from `findFinalComponent` doesn't work because it relied on if the component is wrapped in `withSSRData` explicitly and now that the need for `withSSRData` is gone the implicit components aren't wrapped at the moment of checking them, so I've changed the logic for `hasPreloadedData` to check for the return value of `serverSideInitial`, since if it return it means the view needs the data, and if it doesn't return anything we can set `hasPreloadedData` as false. And to remain backward compatible it also checks for explicit usage of `withSSRData` too.

But I think it's better to remove this check altogether and make both the code and the mental model easier to understand: if you use `serverSideInitial` you automatically get a `initialSSRData` prop that if you return something in your function it's available there but if you don't, it's an empty object and you can ignore it.

## Bug Fix

In the process I also fixed a bug related to using render props for routes that required you to pass both the `component` and `render` properties in the route config to make it work. This bug was caused by `getInitialPropsList` since it was expecting that components only come from the `component` property and not the `render` property.

so basically with the fix you can make routes like this:
```diff
{
- component: Home,
  path: '/',
  render: (props) => <Home {...props} />,
}
```

___

Another possible solution for removing `withSSRData` is to make a babel plugin to wrap the views in `withSSRData` implicitly. An advantage is that it makes the code behave as it was without any further changes, but I chose not to do it that way since it makes the components rely on babel and make further transition to the upcoming toolings (like vite) hard and may make further contributors a little confused about how this stuff works internally.

I would like to hear your ideas too and I'm open to discuss any further changes.
